### PR TITLE
fix(android): use FLAG_IMMUTABLE + explicit intent for USB permission request

### DIFF
--- a/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialImpl.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialImpl.kt
@@ -139,8 +139,17 @@ class UsbSerialImpl(
         }
         store.markPermissionRequested(deviceId)
         pendingPermission[deviceId] = callbackId
-        val intent = Intent(ACTION_USB_PERMISSION).apply { putExtra(EXTRA_DEVICE_ID, deviceId) }
-        val flags = PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        // Explicit intent (scoped to our own package) + FLAG_IMMUTABLE. On Android 14
+        // (API 34+) the system rejects a PendingIntent that is both FLAG_MUTABLE and wraps
+        // an implicit intent, so requestPermission() silently never shows the dialog. The
+        // UsbManager still delivers its result extras to an immutable intent, so immutability
+        // costs us nothing here. See https://developer.android.com/reference/android/app/PendingIntent
+        val intent =
+            Intent(ACTION_USB_PERMISSION).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_DEVICE_ID, deviceId)
+            }
+        val flags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         val pi = PendingIntent.getBroadcast(context, deviceId.hashCode(), intent, flags)
         usbManager.requestPermission(device, pi)
     }


### PR DESCRIPTION
## Problem

On **Android 14 (API 34+)** the system rejects a `PendingIntent` that is both `FLAG_MUTABLE` *and* wraps an **implicit** intent (unless `FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT` is set). The USB permission request used exactly that combination:

```kotlin
val intent = Intent(ACTION_USB_PERMISSION) // implicit — no package set
val flags = PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
```

The result: `UsbManager.requestPermission()` is silently rejected and the permission dialog never appears, so the device can never be opened. Reported in #1.

## Fix

- Scope the intent to our own package (`setPackage(context.packageName)`) so it is **explicit** — satisfies the Android 14 restriction and is a security hardening (no other app can receive the broadcast; pairs with the existing `RECEIVER_NOT_EXPORTED` registration).
- Create the `PendingIntent` with **`FLAG_IMMUTABLE`**, Android's recommended default. `UsbManager` still delivers its result extras to an immutable intent, so this costs nothing.
- `FLAG_UPDATE_CURRENT` retained so the per-device extras refresh on reuse.

This matches the approach used by the upstream `mik3y/usb-serial-for-android` permission example.

## Testing

`./gradlew testDebugUnitTest` → **BUILD SUCCESSFUL**, all unit tests pass.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)