### PR TITLE
fix(android): stream, permission, and attach lifecycle fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Native serial objects can't cross the Capacitor bridge, so the plugin is **handl
 USB permission must be granted **before** a port can be opened:
 
 - `requestPermission({ deviceId })` shows the system dialog and resolves `{ granted }`.
+- Concurrent `requestPermission` calls for the same device **coalesce** onto one dialog;
+  every pending call settles with the same result, and the coalesced ones resolve with
+  `coalesced: true`.
+- If the device detaches while the dialog is pending, the promise **rejects** with
+  `NO_DEVICE` (distinguishable from the user declining, which resolves
+  `{ granted: false }`).
 - `open()` rejects with `NEEDS_PERMISSION` if you never asked, or `PERMISSION_DENIED`
   if the user declined.
 
@@ -116,6 +122,15 @@ Lifecycle: `open`, `close`, `isOpen`, `getPortInfo`.
 Config: `setParameters`.
 I/O: `read`, `write`, `writeAsync`.
 Streaming: `startReading`, `stopReading`, `getStreamState`, `getStreamConfig`, `data`/`error` events.
+
+**Write semantics during streaming:** while a stream is running, `write()` enqueues onto
+the stream's async write queue — `bytesWritten` confirms *acceptance*, not transmission.
+With no running stream, `write()` is synchronous and confirms delivery to the driver.
+
+**Stream errors:** if a stream dies from a run error you get an `error` event and the
+port self-heals — one-shot `read()`/`write()` work again immediately, and
+`getStreamState()` reports `stopped`. Call `startReading()` again to resume streaming.
+If the error was a disconnect you also get `detached`, and the port is reaped.
 Control lines: `getControlLines`, `getSupportedControlLines`, `getCD/CTS/DSR/DTR/RI/RTS`, `setDTR`, `setRTS`.
 Flow control: `setFlowControl`, `getFlowControl`, `getSupportedFlowControl`, `getXON` (+ `CHAR_XON`/`CHAR_XOFF`).
 Maintenance: `purgeHwBuffers`, `setBreak`, `setReadQueue`, `getReadQueueConfig`.

--- a/android/src/main/java/com/capacitorusbserial/plugin/HandleStore.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/HandleStore.kt
@@ -6,11 +6,14 @@ import com.hoho.android.usbserial.driver.UsbSerialPort
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * One open serial port plus everything that must be reaped with it: the native
  * connection, the per-port single-threaded executor that serializes its I/O, and the
- * optional active stream manager.
+ * optional active stream manager. [stream] is an AtomicReference because it is written
+ * from both the bridge dispatch pool (start/stopReading) and the stream's own error
+ * thread (identity-guarded clear on run error).
  */
 class PortHandle(
     val portId: String,
@@ -18,7 +21,7 @@ class PortHandle(
     val port: UsbSerialPort,
     val connection: UsbDeviceConnection,
     val executor: ExecutorService,
-    var stream: SerialStreamManager? = null,
+    val stream: AtomicReference<SerialStreamManager?> = AtomicReference(null),
 )
 
 /**
@@ -106,7 +109,7 @@ class HandleStore {
     fun portsForDevice(deviceId: String): List<PortHandle> = ports.values.filter { it.deviceId == deviceId }
 
     private fun closeHandle(handle: PortHandle) {
-        runCatching { handle.stream?.stop() }
+        runCatching { handle.stream.get()?.stop() }
         runCatching { handle.port.close() }
         runCatching { handle.connection.close() }
         runCatching { handle.executor.shutdownNow() }

--- a/android/src/main/java/com/capacitorusbserial/plugin/UsbEventReceiver.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/UsbEventReceiver.kt
@@ -3,7 +3,6 @@ package com.capacitorusbserial.plugin
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 
 /**
@@ -23,21 +22,13 @@ class UsbEventReceiver(private val impl: UsbSerialImpl) : BroadcastReceiver() {
                 impl.onPermissionResult(deviceId, granted)
             }
             UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
-                val device = device(intent) ?: return
+                val device = UsbIntents.usbDevice(intent) ?: return
                 impl.handleAttached(device, coldStart = false)
             }
             UsbManager.ACTION_USB_DEVICE_DETACHED -> {
-                val device = device(intent) ?: return
+                val device = UsbIntents.usbDevice(intent) ?: return
                 impl.onDeviceDetached(device)
             }
         }
     }
-
-    @Suppress("DEPRECATION")
-    private fun device(intent: Intent): UsbDevice? =
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
-        } else {
-            intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
-        }
 }

--- a/android/src/main/java/com/capacitorusbserial/plugin/UsbIntents.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/UsbIntents.kt
@@ -1,0 +1,19 @@
+package com.capacitorusbserial.plugin
+
+import android.content.Intent
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
+
+/**
+ * Single home for version-gated USB intent extras extraction, shared by the runtime
+ * broadcast receiver and the plugin's cold-start launch-intent inspection.
+ */
+internal object UsbIntents {
+    @Suppress("DEPRECATION")
+    fun usbDevice(intent: Intent): UsbDevice? =
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+        } else {
+            intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+        }
+}

--- a/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialImpl.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialImpl.kt
@@ -28,14 +28,17 @@ import java.util.concurrent.RejectedExecutionException
 class UsbSerialImpl(
     private val context: Context,
     private val emitter: (eventName: String, payload: JSObject) -> Unit,
-    private val resolvePermission: (callbackId: String, granted: Boolean) -> Unit,
+    private val resolvePermission: (callbackId: String, granted: Boolean, coalesced: Boolean) -> Unit,
+    private val rejectPermission: (callbackId: String, code: UsbSerialErrorCode, message: String) -> Unit,
 ) {
     companion object {
         const val ACTION_USB_PERMISSION = "com.capacitorusbserial.plugin.USB_PERMISSION"
         const val EXTRA_DEVICE_ID = "com.capacitorusbserial.plugin.DEVICE_ID"
         private const val DEFAULT_READ_BUFFER = 16 * 1024
+        private const val MAX_READ_BUFFER = 1 shl 20
         private const val DEFAULT_READ_TIMEOUT = 1000
         private const val DEFAULT_WRITE_TIMEOUT = 1000
+        private const val TAG = "UsbSerial"
     }
 
     private val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
@@ -46,8 +49,11 @@ class UsbSerialImpl(
     private val customTable = ProbeTable()
     private var hasCustomMappings = false
 
-    // deviceId -> callbackId awaiting a permission broadcast (Task 21).
-    private val pendingPermission = ConcurrentHashMap<String, String>()
+    // deviceId -> callbackIds awaiting a permission broadcast. Multiple requests for the
+    // same device coalesce onto one system dialog; the atomic remove() on settle is what
+    // guarantees each callback resolves/rejects exactly once under any interleaving of
+    // broadcast, detach, and teardown.
+    private val pendingPermission = ConcurrentHashMap<String, MutableList<String>>()
 
     // Buffered cold-start attach payload, replayed to the first 'attached' listener (Req 12.5).
     @Volatile private var bufferedAttach: JSObject? = null
@@ -69,7 +75,7 @@ class UsbSerialImpl(
             info.put("vendorId", device.vendorId)
             info.put("productId", device.productId)
             info.put("deviceName", device.deviceName)
-            info.put("serialNumber", safeSerial(device, driver))
+            info.put("serialNumber", safeSerial(deviceId, device))
             info.put("driverType", EnumMaps.driverTypeName(driver))
             info.put("portCount", driver.ports.size)
             info.put("hasPermission", usbManager.hasPermission(device))
@@ -80,21 +86,25 @@ class UsbSerialImpl(
 
     /** getSerial() requires permission and an open-ish handle on some drivers; null-safe. */
     private fun safeSerial(
+        deviceId: String,
         device: android.hardware.usb.UsbDevice,
-        @Suppress("UNUSED_PARAMETER") driver: UsbSerialDriver,
-    ): String? =
-        if (!usbManager.hasPermission(device)) {
-            null
-        } else {
-            runCatching {
-                val conn = usbManager.openDevice(device) ?: return null
-                try {
-                    conn.serial
-                } finally {
-                    conn.close()
-                }
-            }.getOrNull()
+    ): String? {
+        if (!usbManager.hasPermission(device)) return null
+        // A second concurrent UsbDeviceConnection can disturb active I/O on some
+        // drivers; reuse the open port's connection when one exists.
+        val openHandle = store.portsForDevice(deviceId).firstOrNull()
+        if (openHandle != null) {
+            return runCatching { openHandle.connection.serial }.getOrNull()
         }
+        return runCatching {
+            val conn = usbManager.openDevice(device) ?: return null
+            try {
+                conn.serial
+            } finally {
+                conn.close()
+            }
+        }.getOrNull()
+    }
 
     // ----------------------------------------------------------------------
     // Task 20 — Custom prober registration
@@ -130,15 +140,30 @@ class UsbSerialImpl(
         return JSObject().put("granted", usbManager.hasPermission(device))
     }
 
-    /** Issues the system permission prompt; resolution arrives via [onPermissionResult]. */
+    /**
+     * Issues the system permission prompt; resolution arrives via [onPermissionResult].
+     * Concurrent requests for the same device coalesce onto the single pending dialog;
+     * only the first caller triggers it, and all callers settle together.
+     */
     fun requestPermission(deviceId: String, callbackId: String) {
         val device = store.getDevice(deviceId)
         if (usbManager.hasPermission(device)) {
-            resolvePermission(callbackId, true)
+            resolvePermission(callbackId, true, false)
             return
         }
         store.markPermissionRequested(deviceId)
-        pendingPermission[deviceId] = callbackId
+        // The first-request decision must happen inside compute (under the bin lock);
+        // checking the returned list's size would race a concurrent append and could
+        // leave no caller issuing the dialog.
+        var first = false
+        pendingPermission.compute(deviceId) { _, v ->
+            if (v == null) first = true
+            (v ?: mutableListOf()).also { it += callbackId }
+        }
+        if (!first) {
+            android.util.Log.w(TAG, "requestPermission($deviceId): coalescing onto pending request")
+            return
+        }
         // Explicit intent (scoped to our own package) + FLAG_IMMUTABLE. On Android 14
         // (API 34+) the system rejects a PendingIntent that is both FLAG_MUTABLE and wraps
         // an implicit intent, so requestPermission() silently never shows the dialog. The
@@ -156,8 +181,16 @@ class UsbSerialImpl(
 
     /** Called by the broadcast receiver when a permission result arrives. */
     fun onPermissionResult(deviceId: String, granted: Boolean) {
-        val callbackId = pendingPermission.remove(deviceId) ?: return
-        resolvePermission(callbackId, granted)
+        val callbackIds = pendingPermission.remove(deviceId) ?: return
+        callbackIds.forEachIndexed { i, callbackId ->
+            resolvePermission(callbackId, granted, i > 0)
+        }
+    }
+
+    /** Reject every pending permission request for [deviceId] (detach/teardown paths). */
+    private fun failPendingPermissions(deviceId: String, message: String) {
+        val callbackIds = pendingPermission.remove(deviceId) ?: return
+        callbackIds.forEach { rejectPermission(it, UsbSerialErrorCode.NO_DEVICE, message) }
     }
 
     // ----------------------------------------------------------------------
@@ -241,8 +274,15 @@ class UsbSerialImpl(
     // ----------------------------------------------------------------------
 
     fun read(portId: String, length: Int?, timeout: Int?): JSObject {
+        if (length != null && length !in 1..MAX_READ_BUFFER) {
+            throw UsbSerialError(
+                UsbSerialErrorCode.INVALID_PARAMS,
+                "length must be between 1 and $MAX_READ_BUFFER, got $length",
+            )
+        }
         val handle = store.getPort(portId)
-        if (handle.stream != null) {
+        // Only a RUNNING stream owns the read endpoint; a dead one no longer blocks.
+        if (handle.stream.get()?.isRunning() == true) {
             throw UsbSerialError(
                 UsbSerialErrorCode.INVALID_STATE,
                 "Cannot one-shot read while a stream is active on port $portId",
@@ -258,9 +298,11 @@ class UsbSerialImpl(
     fun write(portId: String, data: String, timeout: Int?): JSObject {
         val handle = store.getPort(portId)
         val bytes = Base64Util.decode(data)
-        val stream = handle.stream
-        if (stream != null) {
+        val stream = handle.stream.get()
+        if (stream != null && stream.isRunning()) {
             // Route through the manager's async write path while it owns the port.
+            // A dead manager's queue is never drained (library does no state check in
+            // writeAsync), so anything not RUNNING falls through to the direct write.
             stream.writeAsync(bytes)
         } else {
             onPortIo(handle) { handle.port.write(bytes, timeout ?: DEFAULT_WRITE_TIMEOUT) }
@@ -271,11 +313,11 @@ class UsbSerialImpl(
     fun writeAsync(portId: String, data: String) {
         val handle = store.getPort(portId)
         val bytes = Base64Util.decode(data)
-        val stream = handle.stream
-        if (stream != null) {
+        val stream = handle.stream.get()
+        if (stream != null && stream.isRunning()) {
             stream.writeAsync(bytes)
         } else {
-            // No stream: fire-and-forget on the per-port executor so we resolve immediately.
+            // No live stream: fire-and-forget on the per-port executor so we resolve immediately.
             runCatching {
                 handle.executor.submit { runCatching { handle.port.write(bytes, DEFAULT_WRITE_TIMEOUT) } }
             }
@@ -296,17 +338,20 @@ class UsbSerialImpl(
         threadPriority: Int?,
     ) {
         val handle = store.getPort(portId)
-        if (handle.stream?.isRunning() == true) {
+        if (handle.stream.get()?.isRunning() == true) {
             throw UsbSerialError(UsbSerialErrorCode.INVALID_STATE, "Stream already running on port $portId")
         }
-        val manager =
+        lateinit var manager: SerialStreamManager
+        manager =
             SerialStreamManager(
                 portId = portId,
                 port = handle.port,
                 onData = { bytes ->
                     emitter("data", JSObject().put("portId", portId).put("data", Base64Util.encode(bytes)))
                 },
-                onError = { e -> onStreamError(handle, e) },
+                // Capture the manager so the error path can identity-guard its clear: a
+                // late onRunError from this (dying) manager must not clobber a newer one.
+                onError = { e -> onStreamError(handle, manager, e) },
             )
         manager.applyTuning(
             readTimeout,
@@ -317,25 +362,25 @@ class UsbSerialImpl(
             threadPriority,
         )
         manager.start()
-        handle.stream = manager
+        handle.stream.set(manager)
     }
 
     fun stopReading(portId: String) {
         val handle = store.getPort(portId)
-        handle.stream?.stop()
-        handle.stream = null
+        handle.stream.get()?.stop()
+        handle.stream.set(null)
     }
 
     fun getStreamState(portId: String): JSObject {
         val handle = store.getPort(portId)
-        val state = handle.stream?.state() ?: "stopped"
+        val state = handle.stream.get()?.state() ?: "stopped"
         return JSObject().put("state", state)
     }
 
     fun getStreamConfig(portId: String): JSObject {
         val handle = store.getPort(portId)
         val stream =
-            handle.stream
+            handle.stream.get()
                 ?: throw UsbSerialError(UsbSerialErrorCode.INVALID_STATE, "No active stream on port $portId")
         val cfg = stream.configSnapshot()
         return JSObject()
@@ -346,13 +391,17 @@ class UsbSerialImpl(
             .put("readQueueBufferCount", cfg.readQueueBufferCount)
     }
 
-    private fun onStreamError(handle: PortHandle, e: Exception) {
+    private fun onStreamError(handle: PortHandle, dying: SerialStreamManager, e: Exception) {
         emitter("error", JSObject().put("portId", handle.portId).put("message", e.message ?: "stream error"))
-        // If the device is gone, perform detach cleanup and notify.
         if (isDisconnect(handle, e)) {
+            // Device is gone: perform detach cleanup and notify.
             val deviceId = handle.deviceId
             store.reapDevice(deviceId)
             emitter("detached", JSObject().put("deviceId", deviceId))
+        } else {
+            // Port stays usable: detach the dead manager so one-shot I/O resumes.
+            // compareAndSet only — a new stream may already have replaced it.
+            handle.stream.compareAndSet(dying, null)
         }
     }
 
@@ -491,6 +540,7 @@ class UsbSerialImpl(
         if (store.hasDevice(deviceId) || store.portsForDevice(deviceId).isNotEmpty()) {
             store.reapDevice(deviceId)
         }
+        failPendingPermissions(deviceId, "Device detached while permission request pending")
         emitter("detached", JSObject().put("deviceId", deviceId))
     }
 
@@ -503,10 +553,16 @@ class UsbSerialImpl(
 
     fun teardown() {
         store.reapAll()
+        pendingPermission.keys.toList().forEach {
+            failPendingPermissions(it, "Plugin destroyed while permission request pending")
+        }
         pendingPermission.clear()
     }
 
     val permissionAction: String get() = ACTION_USB_PERMISSION
+
+    /** Test seam: the store is private and nothing else exposes a [PortHandle]. */
+    internal fun portHandleForTest(portId: String): PortHandle = store.getPort(portId)
 
     // ----------------------------------------------------------------------
     // Per-port execution helpers
@@ -541,9 +597,15 @@ class UsbSerialImpl(
 
     private fun isDisconnect(handle: PortHandle, e: Throwable): Boolean {
         if (e is UsbSerialError) return e.code == UsbSerialErrorCode.DEVICE_DISCONNECTED
-        val device = runCatching { handle.connection }.getOrNull()
-        // Device considered gone if it is no longer present in the system device list.
-        val present = usbManager.deviceList.values.any { it.deviceName == handle.port.device.deviceName }
-        return !present || device == null || !handle.port.isOpen
+        // Present only if the same device still occupies its path: the OS reuses
+        // /dev/bus/usb/... names, so a bare deviceName match could be a different
+        // device freshly attached to the reused slot.
+        val dev = handle.port.device
+        val current = usbManager.deviceList[dev.deviceName]
+        val present =
+            current != null &&
+                current.vendorId == dev.vendorId &&
+                current.productId == dev.productId
+        return !present || !handle.port.isOpen
     }
 }

--- a/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialPlugin.kt
+++ b/android/src/main/java/com/capacitorusbserial/plugin/UsbSerialPlugin.kt
@@ -32,9 +32,37 @@ class UsbSerialPlugin : Plugin() {
             UsbSerialImpl(
                 context = context.applicationContext,
                 emitter = { name, payload -> notifyListeners(name, payload) },
-                resolvePermission = { callbackId, granted -> resolvePermission(callbackId, granted) },
+                resolvePermission = { callbackId, granted, coalesced ->
+                    resolvePermission(callbackId, granted, coalesced)
+                },
+                rejectPermission = { callbackId, code, message ->
+                    rejectPermission(callbackId, code, message)
+                },
             )
         registerReceiver()
+        consumeLaunchAttachIntent()
+    }
+
+    /**
+     * Cold-start half of the auto-attach flow: when the app was launched by a
+     * USB_DEVICE_ATTACHED intent, buffer the attach for replay to the first 'attached'
+     * listener. Warm attaches are NOT handled here — the runtime receiver gets the
+     * system broadcast, so inspecting onNewIntent too would double-emit.
+     */
+    private fun consumeLaunchAttachIntent() {
+        val intent = activity?.intent ?: return
+        if (intent.action != UsbManager.ACTION_USB_DEVICE_ATTACHED) return
+        val device = UsbIntents.usbDevice(intent) ?: return
+        // removeExtra only mutates the process-local copy; after process death the
+        // original intent is re-delivered from recents, so also verify the device is
+        // still attached before replaying a potentially stale attach.
+        intent.removeExtra(UsbManager.EXTRA_DEVICE)
+        val usbManager = context.getSystemService(android.content.Context.USB_SERVICE) as UsbManager
+        val current = usbManager.deviceList[device.deviceName]
+        if (current == null || current.vendorId != device.vendorId || current.productId != device.productId) {
+            return
+        }
+        impl.handleAttached(current, coldStart = true)
     }
 
     override fun handleOnDestroy() {
@@ -62,9 +90,18 @@ class UsbSerialPlugin : Plugin() {
         receiver = r
     }
 
-    private fun resolvePermission(callbackId: String, granted: Boolean) {
+    private fun resolvePermission(callbackId: String, granted: Boolean, coalesced: Boolean) {
         val saved = bridge.getSavedCall(callbackId) ?: return
-        saved.resolve(JSObject().put("granted", granted))
+        val result = JSObject().put("granted", granted)
+        // Only coalesced results carry the marker; the first caller's shape is unchanged.
+        if (coalesced) result.put("coalesced", true)
+        saved.resolve(result)
+        bridge.releaseCall(saved)
+    }
+
+    private fun rejectPermission(callbackId: String, code: UsbSerialErrorCode, message: String) {
+        val saved = bridge.getSavedCall(callbackId) ?: return
+        saved.reject(message, code.name)
         bridge.releaseCall(saved)
     }
 
@@ -264,7 +301,11 @@ class UsbSerialPlugin : Plugin() {
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     override fun addListener(call: PluginCall) {
         super.addListener(call)
-        if (this::impl.isInitialized) impl.flushBufferedAttach()
+        // Replay the buffered cold-start attach only to an 'attached' listener — flushing
+        // on any registration would emit to zero listeners and lose the payload.
+        if (this::impl.isInitialized && call.getString("eventName") == "attached") {
+            impl.flushBufferedAttach()
+        }
     }
 
     // ----------------------------------------------------------------------

--- a/android/src/test/java/com/capacitorusbserial/plugin/UsbSerialImplTest.kt
+++ b/android/src/test/java/com/capacitorusbserial/plugin/UsbSerialImplTest.kt
@@ -44,7 +44,8 @@ class UsbSerialImplTest {
     private lateinit var prober: UsbSerialProber
 
     private val events = mutableListOf<Pair<String, JSObject>>()
-    private val permissions = mutableListOf<Pair<String, Boolean>>()
+    private val permissions = mutableListOf<Triple<String, Boolean, Boolean>>()
+    private val rejections = mutableListOf<Pair<String, UsbSerialErrorCode>>()
 
     @Before
     fun setUp() {
@@ -60,7 +61,8 @@ class UsbSerialImplTest {
             UsbSerialImpl(
                 context = app,
                 emitter = { name, payload -> events.add(name to payload) },
-                resolvePermission = { id, granted -> permissions.add(id to granted) },
+                resolvePermission = { id, granted, coalesced -> permissions.add(Triple(id, granted, coalesced)) },
+                rejectPermission = { id, code, _ -> rejections.add(id to code) },
             )
     }
 
@@ -88,6 +90,7 @@ class UsbSerialImplTest {
 
         val port = mock(UsbSerialPort::class.java)
         `when`(port.portNumber).thenReturn(0)
+        `when`(port.device).thenReturn(device)
 
         val driver = mock(FtdiSerialDriver::class.java)
         `when`(driver.device).thenReturn(device)
@@ -148,7 +151,7 @@ class UsbSerialImplTest {
         val f = registerDevice(hasPermission = false)
         impl.requestPermission(f.deviceId, "cb1") // marks requested, fires system request
         impl.onPermissionResult(f.deviceId, false) // user denies
-        assertEquals(listOf("cb1" to false), permissions)
+        assertEquals(listOf(Triple("cb1", false, false)), permissions)
         try {
             impl.open(f.deviceId, 0)
             fail("expected PERMISSION_DENIED")
@@ -161,7 +164,7 @@ class UsbSerialImplTest {
     fun requestPermissionResolvesTrueWhenAlreadyGranted() {
         val f = registerDevice(hasPermission = true)
         impl.requestPermission(f.deviceId, "cb2")
-        assertEquals(listOf("cb2" to true), permissions)
+        assertEquals(listOf(Triple("cb2", true, false)), permissions)
     }
 
     @Test
@@ -383,5 +386,165 @@ class UsbSerialImplTest {
         } catch (e: UsbSerialError) {
             assertEquals(UsbSerialErrorCode.DEVICE_DISCONNECTED, e.code)
         }
+    }
+
+    // --- dead-stream gates (a stopped manager must not block or swallow I/O) ---
+
+    /** Inject a never-started manager (state STOPPED => isRunning() false) into the handle. */
+    private fun injectDeadStream(f: Fixture, portId: String): SerialStreamManager {
+        val endpoint = mock(android.hardware.usb.UsbEndpoint::class.java)
+        `when`(endpoint.maxPacketSize).thenReturn(64)
+        `when`(f.port.readEndpoint).thenReturn(endpoint)
+        `when`(f.port.writeEndpoint).thenReturn(endpoint)
+        val manager = SerialStreamManager(portId, f.port, {}, {})
+        impl.portHandleForTest(portId).stream.set(manager)
+        return manager
+    }
+
+    @Test
+    fun writeWithDeadStreamFallsThroughToDirectWrite() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        injectDeadStream(f, portId)
+        val result = impl.write(portId, b64("hi".toByteArray()), null)
+        assertEquals(2, result.getInt("bytesWritten"))
+        verify(f.port).write(any(), anyInt())
+    }
+
+    @Test
+    fun readWithDeadStreamPerformsOneShotRead() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        injectDeadStream(f, portId)
+        `when`(f.port.read(any(), anyInt())).thenReturn(0)
+        assertEquals("", impl.read(portId, 8, 10).getString("data"))
+    }
+
+    @Test
+    fun writeAsyncWithDeadStreamUsesPortExecutor() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        injectDeadStream(f, portId)
+        impl.writeAsync(portId, b64("hi".toByteArray()))
+        impl.portHandleForTest(portId).executor.submit {}.get() // drain the executor
+        verify(f.port).write(any(), anyInt())
+    }
+
+    // --- permission coalescing / exactly-once settling ----------------------
+
+    @Test
+    fun secondRequestCoalescesOntoPendingDialog() {
+        val f = registerDevice(hasPermission = false)
+        impl.requestPermission(f.deviceId, "cb1")
+        impl.requestPermission(f.deviceId, "cb2")
+        verify(usbManager, org.mockito.Mockito.times(1))
+            .requestPermission(any(UsbDevice::class.java), any(android.app.PendingIntent::class.java))
+        impl.onPermissionResult(f.deviceId, true)
+        assertEquals(
+            listOf(Triple("cb1", true, false), Triple("cb2", true, true)),
+            permissions,
+        )
+    }
+
+    @Test
+    fun detachRejectsPendingPermissionsExactlyOnce() {
+        val f = registerDevice(hasPermission = false)
+        impl.requestPermission(f.deviceId, "cb1")
+        impl.requestPermission(f.deviceId, "cb2")
+        impl.onDeviceDetached(f.device)
+        assertEquals(
+            listOf("cb1" to UsbSerialErrorCode.NO_DEVICE, "cb2" to UsbSerialErrorCode.NO_DEVICE),
+            rejections,
+        )
+        // A late broadcast after the detach settle must be a no-op (no double settle).
+        impl.onPermissionResult(f.deviceId, true)
+        assertTrue(permissions.isEmpty())
+        assertEquals(2, rejections.size)
+    }
+
+    @Test
+    fun teardownRejectsPendingPermissions() {
+        val f = registerDevice(hasPermission = false)
+        impl.requestPermission(f.deviceId, "cb1")
+        impl.teardown()
+        assertEquals(listOf("cb1" to UsbSerialErrorCode.NO_DEVICE), rejections)
+    }
+
+    // --- cold-start attach buffering ----------------------------------------
+
+    @Test
+    fun coldStartAttachBuffersAndFlushesExactlyOnce() {
+        val f = registerDevice(hasPermission = true)
+        events.clear()
+        impl.handleAttached(f.device, coldStart = true)
+        assertEquals(1, events.count { it.first == "attached" }) // immediate emit
+        impl.flushBufferedAttach()
+        assertEquals(2, events.count { it.first == "attached" }) // replay to first listener
+        impl.flushBufferedAttach()
+        assertEquals(2, events.count { it.first == "attached" }) // second flush is a no-op
+    }
+
+    // --- isDisconnect identity check -----------------------------------------
+
+    @Test
+    fun reusedDevicePathWithDifferentDeviceClassifiesAsDisconnect() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        // Same /dev path now occupied by a different device (VID mismatch).
+        val imposter = mock(UsbDevice::class.java)
+        `when`(imposter.deviceName).thenReturn("/dev/bus/usb/001/002")
+        `when`(imposter.vendorId).thenReturn(0x1234)
+        `when`(imposter.productId).thenReturn(0x6001)
+        `when`(usbManager.deviceList).thenReturn(hashMapOf("/dev/bus/usb/001/002" to imposter))
+        `when`(f.port.read(any(), anyInt())).thenThrow(IOException("gone"))
+        try {
+            impl.read(portId, 8, 50)
+            fail("expected DEVICE_DISCONNECTED")
+        } catch (e: UsbSerialError) {
+            assertEquals(UsbSerialErrorCode.DEVICE_DISCONNECTED, e.code)
+        }
+    }
+
+    @Test
+    fun presentDeviceWithOpenPortClassifiesAsIoError() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        `when`(f.port.isOpen).thenReturn(true) // Mockito default false would read as disconnect
+        `when`(f.port.read(any(), anyInt())).thenThrow(IOException("transient"))
+        try {
+            impl.read(portId, 8, 50)
+            fail("expected IO_ERROR")
+        } catch (e: UsbSerialError) {
+            assertEquals(UsbSerialErrorCode.IO_ERROR, e.code)
+        }
+    }
+
+    // --- read() length validation --------------------------------------------
+
+    @Test
+    fun readRejectsBadLengths() {
+        val f = registerDevice(hasPermission = true)
+        val portId = openPort(f)
+        for (bad in listOf(0, -1, (1 shl 20) + 1)) {
+            try {
+                impl.read(portId, bad, 10)
+                fail("expected INVALID_PARAMS for length $bad")
+            } catch (e: UsbSerialError) {
+                assertEquals(UsbSerialErrorCode.INVALID_PARAMS, e.code)
+            }
+        }
+        verify(f.port, org.mockito.Mockito.never()).read(any(), anyInt())
+    }
+
+    // --- safeSerial reuses the open connection --------------------------------
+
+    @Test
+    fun listDevicesWithOpenPortDoesNotOpenSecondConnection() {
+        val f = registerDevice(hasPermission = true) // listDevices in helper: 1st openDevice
+        `when`(f.connection.serial).thenReturn("SN123")
+        openPort(f) // 2nd openDevice (the real open)
+        val dev = impl.listDevices().getJSONArray("devices").getJSONObject(0)
+        assertEquals("SN123", dev.getString("serialNumber"))
+        verify(usbManager, org.mockito.Mockito.times(2)).openDevice(f.device)
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -76,6 +76,15 @@ export interface PermissionResult {
   granted: boolean;
 }
 
+export interface RequestPermissionResult extends PermissionResult {
+  /**
+   * Present (true) when this call was coalesced onto a permission request already
+   * pending for the same device: only one system dialog is shown, and every pending
+   * call settles with the same result. Absent on the first (dialog-triggering) call.
+   */
+  coalesced?: boolean;
+}
+
 export interface OpenOptions {
   deviceId: string;
   /** Defaults to 0. */
@@ -111,7 +120,7 @@ export interface SerialParameters {
 
 export interface ReadOptions {
   portId: string;
-  /** Max bytes to read; defaults to an internal buffer size. */
+  /** Max bytes to read, 1..1048576 (1 MiB); defaults to an internal buffer size. */
   length?: number;
   /** Milliseconds; defaults to an internal value. A timeout yields an empty result. */
   timeout?: number;
@@ -246,7 +255,13 @@ export interface UsbSerialPlugin extends Plugin {
   registerDriver(options: RegisterDriverOptions): Promise<void>;
 
   // Permission
-  requestPermission(options: DeviceRef): Promise<PermissionResult>;
+  /**
+   * Shows the system USB permission dialog and resolves with the user's choice.
+   * Concurrent calls for the same device coalesce onto one dialog; coalesced calls
+   * resolve with `coalesced: true`. Rejects with `NO_DEVICE` if the device detaches
+   * (or the plugin is destroyed) while the request is pending.
+   */
+  requestPermission(options: DeviceRef): Promise<RequestPermissionResult>;
   hasPermission(options: DeviceRef): Promise<PermissionResult>;
 
   // Port lifecycle
@@ -260,7 +275,17 @@ export interface UsbSerialPlugin extends Plugin {
 
   // I/O
   read(options: ReadOptions): Promise<ReadResult>;
+  /**
+   * While a stream is RUNNING on the port, the bytes are enqueued onto the stream's
+   * async write queue and `bytesWritten` confirms acceptance, not transmission. With
+   * no running stream the write is synchronous and `bytesWritten` reflects delivery
+   * to the driver.
+   */
   write(options: WriteOptions): Promise<WriteResult>;
+  /**
+   * Fire-and-forget write: resolves on acceptance, never confirms transmission.
+   * Uses the stream's queue while one is RUNNING, the port executor otherwise.
+   */
   writeAsync(options: WriteAsyncOptions): Promise<void>;
 
   // Streaming

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,6 +7,7 @@ import type {
   RegisterDriverOptions,
   DeviceRef,
   PermissionResult,
+  RequestPermissionResult,
   OpenOptions,
   OpenResult,
   PortRef,
@@ -60,7 +61,7 @@ export class WebUsbSerial extends WebPlugin implements UsbSerialPlugin {
   registerDriver(_options: RegisterDriverOptions): Promise<void> {
     return unsupported();
   }
-  requestPermission(_options: DeviceRef): Promise<PermissionResult> {
+  requestPermission(_options: DeviceRef): Promise<RequestPermissionResult> {
     return unsupported();
   }
   hasPermission(_options: DeviceRef): Promise<PermissionResult> {


### PR DESCRIPTION
## What

Fixes four verified lifecycle bugs found in a post-#2 code review, plus three hardening items. Spec-driven: requirements, design, and task breakdown were each validated before implementation.

### 1. Dead-stream wedge (silent data loss)
`SerialInputOutputManager.writeAsync()` does no state check (verified against usb-serial-for-android 3.10.0 source) — it silently queues into a STOPPED manager. After a stream run-error the plugin kept the dead manager on the handle, so:
- `write()` reported `bytesWritten: N` success while the bytes were **never sent**
- `read()` falsely rejected `INVALID_STATE`

Now all one-shot I/O gates on `isRunning()` instead of mere existence, and `onStreamError` detaches the dead manager with an identity-guarded `compareAndSet` (a late error from a dying manager can't clobber a replacement stream). `PortHandle.stream` became an `AtomicReference`.

### 2. requestPermission() promises could hang forever
- A second request for the same device overwrote the pending callback — first promise never settled.
- Detach during the dialog, or plugin teardown, leaked the saved bridge call.

Now: concurrent requests **coalesce** onto one system dialog (first-request decision made inside `ConcurrentHashMap.compute`, under the bin lock; the atomic `remove()` settles every caller exactly once under any broadcast/detach/teardown interleaving). Coalesced calls resolve with `coalesced: true` (additive `RequestPermissionResult` type). Detach/teardown rejects pending calls with `NO_DEVICE`.

### 3. Cold-start attach replay was dead code
The README documented that launching via `USB_DEVICE_ATTACHED` replays an `attached` event — but `handleAttached(coldStart = true)` had no caller. `load()` now consumes the launch intent (verifying the device is still attached, so a stale intent re-delivered from recents can't replay a long-gone device), and the buffered payload is flushed only to an `attached` listener instead of any listener type. Warm attaches stay receiver-only (no `onNewIntent` double-emit).

### 4. Hardening
- `isDisconnect`: device identity = `deviceName` + VID/PID (the OS reuses `/dev/bus/usb/...` paths); removed an unreachable null-check arm
- `read()`: `length` validated to 1..1 MiB → `INVALID_PARAMS` (was `NegativeArraySizeException` → `IO_ERROR`)
- `listDevices()`: reuses an open port's connection for the serial number instead of opening a second concurrent `UsbDeviceConnection`

## API impact

Additive only — existing consumers compile unchanged. `RequestPermissionResult` gains optional `coalesced`; no new error codes; `write`/`writeAsync` enqueue-vs-delivery semantics documented in README and `definitions.ts`.

## Testing

- 14 new Robolectric tests (dead-stream gates, coalescing/exactly-once settling, cold-start buffering, disconnect identity, length validation, connection reuse)
- Full suite: **64 Android + 36 web tests passing**, TS build clean
- Hardware-only paths (real cold-start, unplug mid-stream, dialog detach) documented in a manual test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)