### PR TITLE
feat(ios): add reject-with-UNSUPPORTED_PLATFORM stub

### DIFF
--- a/CapacitorUsbSerial.podspec
+++ b/CapacitorUsbSerial.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'CapacitorUsbSerial'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target  = '13.0'
+  s.dependency 'Capacitor'
+  s.swift_version = '5.1'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "CapacitorUsbSerial",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(
+            name: "CapacitorUsbSerial",
+            targets: ["UsbSerialPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+    ],
+    targets: [
+        .target(
+            name: "UsbSerialPlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "ios/Sources/UsbSerialPlugin")
+    ]
+)

--- a/ios/Sources/UsbSerialPlugin/UsbSerialPlugin.swift
+++ b/ios/Sources/UsbSerialPlugin/UsbSerialPlugin.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Capacitor
+
+/**
+ * iOS stub. The underlying mik3y/usb-serial-for-android library and the Android USB
+ * Host API have no iOS counterpart (USB serial access on iOS is limited to MFi /
+ * ExternalAccessory, a different domain), so every bridged method rejects with the
+ * stable `UNSUPPORTED_PLATFORM` code — mirroring the web stub. This exists only so the
+ * package installs and `pod install` / SPM resolve cleanly on iOS targets.
+ */
+@objc(UsbSerialPlugin)
+public class UsbSerialPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "UsbSerialPlugin"
+    public let jsName = "UsbSerial"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "listDevices", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "registerDriver", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "requestPermission", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hasPermission", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "open", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "close", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isOpen", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getPortInfo", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setParameters", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "read", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "write", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "writeAsync", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "startReading", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "stopReading", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStreamState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStreamConfig", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getControlLines", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedControlLines", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getCD", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getCTS", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getDSR", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getDTR", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getRI", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getRTS", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setDTR", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setRTS", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setFlowControl", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getFlowControl", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedFlowControl", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getXON", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "purgeHwBuffers", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setBreak", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setReadQueue", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getReadQueueConfig", returnType: CAPPluginReturnPromise)
+    ]
+
+    private func unsupported(_ call: CAPPluginCall) {
+        call.reject("USB serial is only available on Android.", "UNSUPPORTED_PLATFORM")
+    }
+
+    @objc func listDevices(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func registerDriver(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func requestPermission(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func hasPermission(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func open(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func close(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func isOpen(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getPortInfo(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setParameters(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func read(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func write(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func writeAsync(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func startReading(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func stopReading(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getStreamState(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getStreamConfig(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getControlLines(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getSupportedControlLines(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getCD(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getCTS(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getDSR(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getDTR(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getRI(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getRTS(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setDTR(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setRTS(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setFlowControl(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getFlowControl(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getSupportedFlowControl(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getXON(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func purgeHwBuffers(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setBreak(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func setReadQueue(_ call: CAPPluginCall) { unsupported(call) }
+    @objc func getReadQueueConfig(_ call: CAPPluginCall) { unsupported(call) }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "android/build.gradle",
     "dist/",
     "ios/Sources/",
-    "ios/Tests/",
     "Package.swift",
     "CapacitorUsbSerial.podspec"
   ],


### PR DESCRIPTION
## Why

`package.json` `files[]` declared `Package.swift`, the podspec, and `ios/` — but those files didn't exist in the repo, so npm silently skipped them. On an iOS Capacitor project, `npx cap sync ios` could then choke on the missing podspec. With the package about to be published to `latest` (installable by default), that needed fixing first.

## What

- `Package.swift` + `CapacitorUsbSerial.podspec` (mirrors the standard Capacitor v7 template; podspec reads name/version/etc. from `package.json`).
- `ios/Sources/UsbSerialPlugin/UsbSerialPlugin.swift` — a `CAPPlugin`/`CAPBridgedPlugin` that registers all **34** bridged methods, each rejecting with the stable `UNSUPPORTED_PLATFORM` code. This mirrors the existing web stub (`src/web.ts`) and the documented contract ("iOS and web are stubs that reject every call with `UNSUPPORTED_PLATFORM`").
- Dropped the unused `ios/Tests/` entry from `files[]` (no test ships).

`jsName` is `UsbSerial`, matching `registerPlugin('UsbSerial', …)` in `src/index.ts` and the Android `@CapacitorPlugin(name = "UsbSerial")`.

## Effect

The package now installs and resolves (CocoaPods + SPM) cleanly on iOS, where every call rejects with `UNSUPPORTED_PLATFORM` instead of risking a `cap sync` failure. USB serial remains Android-only by design.

## Note

Swift can't be compiled on this Linux box — the stub follows the official Capacitor v7 plugin-template pattern exactly, but a quick `pod install` / Xcode build on a Mac is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)