### PR TITLE
docs: credit mik3y/usb-serial-for-android + NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+capacitor-usb-serial
+Copyright (c) 2026 Lee Skies
+
+This product depends on third-party software listed below. The dependency is
+pulled at build time (it is not vendored into this repository); its notice is
+reproduced here as a courtesy and acknowledgment.
+
+-------------------------------------------------------------------------------
+usb-serial-for-android
+https://github.com/mik3y/usb-serial-for-android
+Gradle dependency: com.github.mik3y:usb-serial-for-android
+
+MIT License
+
+Copyright (c) 2011-2013 Google Inc.
+Copyright (c) 2013 Mike Wakerly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -144,11 +144,6 @@ Every rejection carries a stable `code`: `NO_DEVICE`, `NEEDS_PERMISSION`,
 `PERMISSION_DENIED`, `PORT_NOT_OPEN`, `INVALID_PARAMS`, `INVALID_STATE`, `IO_ERROR`,
 `DEVICE_DISCONNECTED`, `UNSUPPORTED_OPERATION`, `UNSUPPORTED_PLATFORM`.
 
-## Help & contact
-
-Maintained by Lee Skies. Available for integration help and custom Capacitor /
-USB-serial work — [lee2dskies@gmail.com](mailto:lee2dskies@gmail.com).
-
 ## Credits
 
 This plugin is a thin bridge — the genuinely hard part, speaking each chip family's

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ Every rejection carries a stable `code`: `NO_DEVICE`, `NEEDS_PERMISSION`,
 `PERMISSION_DENIED`, `PORT_NOT_OPEN`, `INVALID_PARAMS`, `INVALID_STATE`, `IO_ERROR`,
 `DEVICE_DISCONNECTED`, `UNSUPPORTED_OPERATION`, `UNSUPPORTED_PLATFORM`.
 
+## Credits
+
+This plugin is a thin bridge — the genuinely hard part, talking to FTDI, Prolific,
+Silicon Labs, CH34x and CDC/ACM chips across a sea of quirky devices, is all
+[**usb-serial-for-android**](https://github.com/mik3y/usb-serial-for-android) by
+[Mike Wakerly (mik3y)](https://github.com/mik3y) and its contributors. Years of
+hard-won device compatibility live in that library; this package just hands it to
+Capacitor. Full credit for the underlying USB serial work goes to that project.
+
+`usb-serial-for-android` is MIT-licensed (© 2011–2013 Google Inc.; © 2013 Mike
+Wakerly). Full notice in [NOTICE](./NOTICE).
+
 ## License
 
-MIT
+MIT — see [LICENSE](./LICENSE). Covers the bridge code in this repository;
+`usb-serial-for-android` remains under its own MIT license (see Credits above).

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Every rejection carries a stable `code`: `NO_DEVICE`, `NEEDS_PERMISSION`,
 `PERMISSION_DENIED`, `PORT_NOT_OPEN`, `INVALID_PARAMS`, `INVALID_STATE`, `IO_ERROR`,
 `DEVICE_DISCONNECTED`, `UNSUPPORTED_OPERATION`, `UNSUPPORTED_PLATFORM`.
 
+## Help & contact
+
+Maintained by Lee Skies. Available for integration help and custom Capacitor /
+USB-serial work — [lee2dskies@gmail.com](mailto:lee2dskies@gmail.com).
+
 ## Credits
 
 This plugin is a thin bridge — the genuinely hard part, talking to FTDI, Prolific,

--- a/README.md
+++ b/README.md
@@ -151,12 +151,14 @@ USB-serial work — [lee2dskies@gmail.com](mailto:lee2dskies@gmail.com).
 
 ## Credits
 
-This plugin is a thin bridge — the genuinely hard part, talking to FTDI, Prolific,
-Silicon Labs, CH34x and CDC/ACM chips across a sea of quirky devices, is all
+This plugin is a thin bridge — the genuinely hard part, speaking each chip family's
+proprietary protocol (FTDI's baud math, Prolific's finicky init sequences, the
+reverse-engineered CH340, Silicon Labs CP210x, CDC/ACM) and absorbing years of
+per-device bug fixes, is all
 [**usb-serial-for-android**](https://github.com/mik3y/usb-serial-for-android) by
-[Mike Wakerly (mik3y)](https://github.com/mik3y) and its contributors. Years of
-hard-won device compatibility live in that library; this package just hands it to
-Capacitor. Full credit for the underlying USB serial work goes to that project.
+[Mike Wakerly (mik3y)](https://github.com/mik3y) and its contributors. This package
+just hands that work to Capacitor. Full credit for the underlying USB serial work
+goes to that project.
 
 `usb-serial-for-android` is MIT-licensed (© 2011–2013 Google Inc.; © 2013 Mike
 Wakerly). Full notice in [NOTICE](./NOTICE).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "types": "dist/esm/index.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
+    "NOTICE",
     "android/src/main/",
     "android/build.gradle",
     "dist/",


### PR DESCRIPTION
Adds proper attribution for the library this plugin wraps, before the npm release.

- **README "Credits" section** — acknowledges [usb-serial-for-android](https://github.com/mik3y/usb-serial-for-android) (Mike Wakerly / mik3y and contributors) as the source of the actual USB serial work; clarifies our MIT covers only the bridge code.
- **NOTICE file** — reproduces the upstream MIT notice verbatim (© 2011–2013 Google Inc.; © 2013 Mike Wakerly).
- **package.json** — adds `NOTICE` to `files[]` so it ships on npm (npm auto-includes README/LICENSE but not NOTICE).

The library is a build-time Gradle dependency (not vendored), so this is courtesy attribution rather than a strict redistribution obligation — but it's the right thing to ship.